### PR TITLE
add deps for speech and html conversion, add right click menu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,14 @@ RUN \
     libxcb-randr0 \
     libxcb-render-util0 \
     libxcb-xinerama0 \
+    poppler-utils \
     python3 \
     python3-xdg \
     ttf-wqy-zenhei \
     wget \
     xz-utils && \
+  apt-get install -y \
+    speech-dispatcher && \
   echo "**** install calibre ****" && \
   mkdir -p \
     /opt/calibre && \

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.02.22:** - Add speech support to bionic image.
 * **05.01.22:** - Add arch branch for arm platforms.
 * **20.04.21:** - Fix the HOME folder.
 * **19.04.21:** - Add libnss3 back in. Make sure Calibre can access environment variables.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -61,6 +61,7 @@ app_setup_block: |
   You can access advanced features of the Guacamole remote desktop using `ctrl`+`alt`+`shift` enabling you to use remote copy/paste and different languages.
 # changelog
 changelogs:
+  - { date: "28.02.22:", desc: "Add speech support to bionic image." }
   - { date: "05.01.22:", desc: "Add arch branch for arm platforms." }
   - { date: "20.04.21:", desc: "Fix the HOME folder." }
   - { date: "19.04.21:", desc: "Add libnss3 back in. Make sure Calibre can access environment variables." }

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openbox_menu xmlns="http://openbox.org/3.4/menu">
+<menu id="root-menu" label="MENU">
+<item label="Calibre GUI"><action name="Execute"><command>/usr/bin/calibre</command></action></item>
+<item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
+<item label="Reload OB"><action name="Reconfigure"/></item>
+</menu>
+</openbox_menu>

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+/startpulse.sh &
+/usr/bin/openbox-session > /dev/null 2>&1

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -14,6 +14,12 @@ else
     echo "**** No auth enabled. To enable auth, you can set the PASSWORD var in docker arguments. ****"
 fi
 
+# default file copies first run
+[[ ! -f /config/.config/openbox/menu.xml ]] && \
+    mkdir -p /config/.config/openbox && \
+    cp /defaults/menu.xml /config/.config/openbox/menu.xml && \
+    chown -R abc:abc /config/.config
+
 # permissions
 chown -R abc:abc \
     /config \


### PR DESCRIPTION
Closes #61 

Added some deps for speech and html conversion. 
Added the right click menu
Update init to force pulseaudio to start (this is in other baseimages just not bionic)

You can test read aloud by right clicking an open ebook and selecting read aloud. This does not work properly in Arch as they name the dic files differently for speech synthesis and calibre has them coded to Ubuntu filenames/paths. 