### PR TITLE
Add documentation for the parameter TITLE

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "PASSWORD", env_value: "", desc: "Optionally set a password for the gui." }
   - { env_var: "CLI_ARGS", env_value: "", desc: "Optionally pass cli start arguments to calibre."}
+  - { env_var: "TITLE", env_value: "Calibre", desc: "String which will be used as page/tab title in the web browser." }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
 opt_param_device_map: false


### PR DESCRIPTION
The string, which is used as html page title and usually shown as window or tab title in the browser can be modified with the environment variable `TITLE`. As this is so far undocumented, this commit adds the relevant sections.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-webtop/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
The string, which is used as html page title and usually shown as window or tab title in the browser can be modified with the environment variable `TITLE`. As this is so far undocumented, this commit adds the relevant sections.

## Benefits of this PR and context:
The window or tab title can be adapted. Fixes https://github.com/linuxserver/docker-calibre/issues/99

## How Has This Been Tested?
I simply added the environment variable to the docker-compose.yml file I was already using and recreated the container. The successful change of the window/tab title could be seen right away.

