### PR TITLE
Qtwebengine disable

### DIFF
--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-s6-envdir -fn -- /var/run/s6/container_environment /bin/bash -c 'umask ${UMASK:-022} && LD_PRELOAD=/opt/calibre/lib/libffi.so.6 /usr/bin/calibre --no-update-check $CLI_ARGS'
+s6-envdir -fn -- /var/run/s6/container_environment /bin/bash -c 'umask ${UMASK:-022} && QTWEBENGINE_DISABLE_SANDBOX=1 && LD_PRELOAD=/opt/calibre/lib/libffi.so.6 /usr/bin/calibre --no-update-check $CLI_ARGS'

--- a/root/etc/s6-overlay/s6-rc.d/init-calibre-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-calibre-config/run
@@ -18,5 +18,4 @@ fi
 
 # permissions
 lsiown -R abc:abc \
-    /config \
-    /opt/calibre
+    /config


### PR DESCRIPTION
currently, a lot of qtwebengine errors happen, some which prevent using basic functions of calibre. disabling the qtwebengine sandbox resolves those and fixes the use of things like ebook-viewer.  Internally, we also discussed not chowning /opt/calibre, so this does that too. I will test the PR 